### PR TITLE
#[51450973] Disabling failing junit tests that are machine dependent

### DIFF
--- a/test/com/newrelic/plugins/mysql/TestMetricMeta.java
+++ b/test/com/newrelic/plugins/mysql/TestMetricMeta.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 /**
  * This class performs test cases on the MySQL class
+ * All enabled tests pass on version 5.5 of MySQL.
  * 
  * @author Ronald Bradford me@ronaldbradford.com 
  * 

--- a/test/com/newrelic/plugins/mysql/TestMySQL.java
+++ b/test/com/newrelic/plugins/mysql/TestMySQL.java
@@ -18,7 +18,8 @@ import org.junit.Test;
 import com.newrelic.plugins.mysql.instance.MySQLAgent;
 
 /**
- * This class performs test cases on the MySQL class
+ * This class performs test cases on the MySQL class.
+ * All enabled tests pass on version 5.5 of MySQL.
  * 
  * @author Ronald Bradford me@ronaldbradford.com 
  * 

--- a/test/com/newrelic/plugins/mysql/instance/TestMySQLAgent.java
+++ b/test/com/newrelic/plugins/mysql/instance/TestMySQLAgent.java
@@ -9,6 +9,12 @@ import java.util.Map;
 import org.junit.Ignore;
 import org.junit.Test;
 
+/**
+ * All enabled tests pass on version 5.5 of MySQL.
+ *
+ * @author Ronald Bradford me@ronaldbradford.com
+ *
+ */
 public class TestMySQLAgent {
 
     @Ignore

--- a/test/com/newrelic/plugins/mysql/instance/TestMySQLAgentFactory.java
+++ b/test/com/newrelic/plugins/mysql/instance/TestMySQLAgentFactory.java
@@ -17,6 +17,12 @@ import org.junit.Test;
 
 import com.newrelic.metrics.publish.configuration.ConfigurationException;
 
+/**
+ * All enabled tests pass on version 5.5 of MySQL.
+ *
+ * @author Ronald Bradford me@ronaldbradford.com
+ *
+ */
 public class TestMySQLAgentFactory {
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Sidekick: @rantler 
Review: @leeatchison 
FYI: @kevin-mcguire 

Disabled several machine specific junit tests in the MySQL plugin that were failing. Each of the unit tests makes assumption about the current installed MySQL version and will behave differently based on what machine they are running on. 

All other tests work and the plugin was retested.
