### PR TITLE
Fixed pid file not being found on debian 4.4

### DIFF
--- a/scripts/etc/init.d/newrelic-mysql-plugin.debian
+++ b/scripts/etc/init.d/newrelic-mysql-plugin.debian
@@ -79,7 +79,7 @@ case "$1" in
         esac
         ;;
     status)
-        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
         ;;
     #reload)
         # not implemented


### PR DESCRIPTION
I had a problem where the _/etc/init.d/newrelic-mysql-plugin status_ always returned "Failed" even if "ps aux | grep newrelic" showed the process running and data being sent to newrelic.
