### PR TITLE
Program "status" requires "PID file" parameter

### DIFF
--- a/scripts/etc/init.d/newrelic-mysql-plugin.rh
+++ b/scripts/etc/init.d/newrelic-mysql-plugin.rh
@@ -67,7 +67,7 @@ case "$1" in
 	stop
 	;;
   status)
-	status $prog
+	status $prog -p ${PID_FILE}
 	;;
   restart|force-reload)
 	stop


### PR DESCRIPTION
On at least CentOS 6.4, the system program "status" requires a PID file in order for it to work. Don't know if this used to work previously, if so I hope that a new parameter won't break compatibility.
