### PR TITLE
Fix debian init script integration with /etc/default env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ You can use services like these to manage this process.
 - [Runit](http://smarden.org/runit/)
 - [Monit](http://mmonit.com/monit/)
 
+### Debian init script configuration
+The debian init script will import environment variables from /etc/default/newrelic-mysql-plugin
+
+Set the DAEMONDIR variable to the directory where you have installed the agent
 ## For support
 Plugin support and troubleshooting assistance can be obtained by visiting [support.newrelic.com](https://support.newrelic.com)
 

--- a/scripts/etc/default/newrelic-mysql-plugin
+++ b/scripts/etc/default/newrelic-mysql-plugin
@@ -1,0 +1,1 @@
+DAEMONDIR=/path/to/newrelic/plugin

--- a/scripts/etc/init.d/newrelic-mysql-plugin.debian
+++ b/scripts/etc/init.d/newrelic-mysql-plugin.debian
@@ -25,15 +25,15 @@ SCRIPTNAME=/etc/init.d/$NAME
 JAVA=/usr/bin/java
 DAEMONDIR=/path/to/plugins
 
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
 # Exit if the package is not installed
 if test ! -x $JAVA -o ! -e $DAEMONDIR/$DAEMON 
 then
     echo $JAVA or $DAEMONDIR/$DAEMON do not exist
     exit 0
 fi
-
-# Read configuration variable file if it is present
-[ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
 . /lib/init/vars.sh
 . /lib/lsb/init-functions


### PR DESCRIPTION
- Load /etc/default/newrelic-mysql-plugin environment variables
  before checking the value of these variables for sanity.
- Updated README to include instructions for setting the DAEMONDIR
  variable when using a debian system
