### PR TITLE
Redhat/CentoOS init.d Script

### DIFF
--- a/scripts/etc/init.d/newrelic-mysql-plugin.redhat
+++ b/scripts/etc/init.d/newrelic-mysql-plugin.redhat
@@ -24,7 +24,7 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 JAVA=/usr/bin/java
 DAEMON_USER=newrelic
-DAEMONDIR=/opt/newrelic_mysql
+DAEMONDIR=/PATH/TO/PLUGIN
 
 . /etc/init.d/functions
 


### PR DESCRIPTION
Very basic init.d script for Redhat/CentOS.
- This will run as root 

This was based of the Debian script by Joe Niland.

Features: Start, Stop and Status
