### PR TITLE
Fixing bug for circular download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Additional information on using Chef and Puppet with New Relic is available in N
 
 #### Step 1 - Downloading and Extracting the Plugin
 
-The latest version of the plugin can be downloaded [here](https://rpm.newrelic.com/extensions/com.newrelic.plugins.mysql.instance).  Once the plugin is on your box, extract it to a location of your choosing.
+The latest version of the plugin can be downloaded [here](https://github.com/newrelic-platform/newrelic_mysql_java_plugin/tree/master/dist).  Once the plugin is on your box, extract it to a location of your choosing.
 
 **note** - This plugin is distributed in tar.gz format and can be extracted with the following command on Unix-based systems (Windows users will need to download a third-party extraction tool or use the [New Relic Platform Installer](https://discuss.newrelic.com/t/getting-started-with-the-platform-installer/842)):
 


### PR DESCRIPTION
There was an issue where RPM linked to Github and Github linked to RPM.

FYI: @briandela @tmacie 
