### PR TITLE
Fixed usage message in RedHat init script

### DIFF
--- a/scripts/etc/init.d/newrelic-mysql-plugin.rh
+++ b/scripts/etc/init.d/newrelic-mysql-plugin.rh
@@ -83,6 +83,6 @@ case "$1" in
 	exit 3
 	;;
   *)
-	echo $"Usage: $0 {start|stop|status|restart|try-restart|force-reload}"
+	echo "Usage: $0 {start|stop|status|restart|try-restart|force-reload}"
 	exit 2
 esac


### PR DESCRIPTION
Currently, running the RedHat init script on its own produces the output "force-reload}", this commit corrects the usage message to output "Usage: /etc/init.d/newrelic-mysql {start|stop|status|restart|try-restart|force-reload}".
