### PR TITLE
Typo, 'varies' to 'various'

### DIFF
--- a/src/com/newrelic/plugins/mysql/instance/MySQLAgent.java
+++ b/src/com/newrelic/plugins/mysql/instance/MySQLAgent.java
@@ -121,7 +121,7 @@ public class MySQLAgent extends Agent {
     }
 
     /**
-     * This method runs the varies categories of MySQL statements and gathers the metrics that can be reported
+     * This method runs the various categories of MySQL statements and gathers the metrics that can be reported
      * 
      * @param Connection c MySQL Database Connection
      * @param String List of metrics to be obtained for this agent


### PR DESCRIPTION
Fixing a small typo in a method comment that was using 'varies' instead of 'various'
